### PR TITLE
enable jobscript_gen

### DIFF
--- a/statebatch/statebatch/STATEbatch.py
+++ b/statebatch/statebatch/STATEbatch.py
@@ -22,7 +22,7 @@ class Batch:
         df          = pd.read_csv(self.comp_spec.get('csv_loc'))
         self.atoms_to_run = df.to_dict(orient='index')
 
-    def prerun(self):
+    def prerun(self, make_jobscript=False):
         def manage_system_params():
             for param in self.system_spec.get('fix_params'):
                 for idx in range(len(self.atoms_to_run)):
@@ -56,16 +56,16 @@ class Batch:
         def build(atom_to_run):
             if (self.system_spec.get('type') == 'Atom'):
                 _atoms       = atom_to_run['Species']
-                self.atoms_obj = Atoms(_atoms)
-                self.atoms_obj.set_cell(atom_to_run['Vacuum']*np.identity(3))
+                atoms_obj = Atoms(_atoms)
+                atoms_obj.set_cell(atom_to_run['Vacuum']*np.identity(3))
             elif (self.system_spec.get('type') == 'Molecule'):
                 _atoms = atom_to_run['Molecule']
-                self.atoms_obj = molecule(_atoms)
-                self.atoms_obj.set_cell(atom_to_run['Vacuum']*np.identity(3))
+                atoms_obj = molecule(_atoms)
+                atoms_obj.set_cell(atom_to_run['Vacuum']*np.identity(3))
             elif (self.system_spec.get('type') == 'Bulk'):
                 _atoms = atom_to_run['Bulk']
                 crystalstructure = atom_to_run['Crystalstructure']
-                self.atoms_obj = bulk(_atoms, crystalstructure=crystalstructure)
+                atoms_obj = bulk(_atoms, crystalstructure=crystalstructure)
             elif (self.system_spec.get('type') == 'Surface' or self.system_spec.get('type') == 'Adsorption'):
                 _atoms = atom_to_run['Surface']
                 crystalstructure = atom_to_run['Crystalstructure']
@@ -73,36 +73,58 @@ class Batch:
                 size = eval(atom_to_run['Size'])
                 vacuum = 0.5*atom_to_run['Vacuum']
                 if (crystalstructure+facet == 'fcc100'):
-                    self.atoms_obj = fcc100(_atoms, size=size, vacuum=vacuum)
+                    atoms_obj = fcc100(_atoms, size=size, vacuum=vacuum)
                 elif (crystalstructure+facet == 'fcc110'):
-                    self.atoms_obj = fcc110(_atoms, size=size, vacuum=vacuum)
+                    atoms_obj = fcc110(_atoms, size=size, vacuum=vacuum)
                 elif (crystalstructure+facet == 'fcc111'):
-                    self.atoms_obj = fcc111(_atoms, size=size, vacuum=vacuum)
+                    atoms_obj = fcc111(_atoms, size=size, vacuum=vacuum)
                 elif (crystalstructure+facet == 'bcc100'):
-                    self.atoms_obj = bcc100(_atoms, size=size, vacuum=system_vacuum)
+                    atoms_obj = bcc100(_atoms, size=size, vacuum=system_vacuum)
                 elif (crystalstructure+facet == 'bcc110'):
-                    self.atoms_obj = bcc110(_atoms, size=size, vacuum=system_vacuum)
+                    atoms_obj = bcc110(_atoms, size=size, vacuum=system_vacuum)
                 elif (crystalstructure+facet == 'bcc111'):
-                    self.atoms_obj = bcc111(_atoms, size=size, vacuum=system_vacuum)
+                    atoms_obj = bcc111(_atoms, size=size, vacuum=system_vacuum)
 
                 if (self.system_spec.get('type') == 'Adsorption'):
                     _adsorbate = atom_to_run['Adsorbate']
-                    self.adsorbate_obj = molecule(_adsorbate)
-                    add_adsorbate(self.atoms_obj, self.adsorbate_obj, height = atom_to_run['Height'], position = atom_to_run['Site'])
+                    adsorbate_obj = molecule(_adsorbate)
+                    add_adsorbate(atoms_obj, adsorbate_obj, height = atom_to_run['Height'], position = atom_to_run['Site'])
 
 
             input_data = get_dft_params(atom_to_run)
             label = f"{_atoms}"
             input_file, output_file = f"{label}.in", f"{label}.out"
-            self.atoms_obj.calc = STATE(label=label, input_data=input_data)
-            self.atoms_obj.calc.write_input(self.atoms_obj)
-            self.atoms_obj.write(f"{label}.xyz")
+            atoms_obj.calc = STATE(label=label, input_data=input_data)
+            atoms_obj.calc.write_input(atoms_obj)
+            atoms_obj.write(f"{label}.xyz")
+
+            return (atoms_obj, input_file, output_file)
+
+        def write_jobscript(idx, cwd, input_file, output_file):
+            n_cpus  = self.comp_spec.get('n_cpus')
+            pw_name = self.comp_spec.get('pw_name')
+            mpi_command = self.comp_spec.get('mpi_command')
+            command = f"{mpi_command} -np {n_cpus} ./{pw_name} < {input_file} > {output_file}"
+            if (idx == 0):
+                mode = 'w'
+            else:
+                mode = 'a'
+            with open ("jobscript.txt", mode) as f:
+                print (f"# Run system with idx {'{:04d}'.format(idx)}", file = f)
+                print (f"pushd {cwd}", file = f)
+                print (command, file = f)
+                print ("popd", file = f)
+                print (file = f)
         
         manage_system_params()
         for idx in range(len(self.atoms_to_run)):
-            dirname = self.comp_spec.get('prefix')+str(idx)
+            cwd = os.getcwd()
+            dirname = self.comp_spec.get('prefix')+str('{:04d}'.format(idx))
             os.makedirs(dirname, exist_ok=True)
             os.chdir(dirname)
             link()
-            build(self.atoms_to_run[idx])
+            _, input_file, output_file = build(self.atoms_to_run[idx])
             os.chdir('../')
+            if make_jobscript is True: write_jobscript(idx, cwd, input_file, output_file) 
+
+        

--- a/statebatch/statebatch/STATEbatch.py
+++ b/statebatch/statebatch/STATEbatch.py
@@ -9,6 +9,7 @@ from ase.build import molecule, bulk, fcc100, fcc110, fcc111, bcc100, bcc110, bc
 from ase.data import atomic_masses, atomic_numbers
 from ase.db import connect
 import yaml
+from .jobutils import *
 
 class Batch:
     def __init__(self, yaml_f):
@@ -100,22 +101,6 @@ class Batch:
 
             return (atoms_obj, input_file, output_file)
 
-        def write_jobscript(idx, cwd, input_file, output_file):
-            n_cpus  = self.comp_spec.get('n_cpus')
-            pw_name = self.comp_spec.get('pw_name')
-            mpi_command = self.comp_spec.get('mpi_command')
-            command = f"{mpi_command} -np {n_cpus} ./{pw_name} < {input_file} > {output_file}"
-            if (idx == 0):
-                mode = 'w'
-            else:
-                mode = 'a'
-            with open ("jobscript.txt", mode) as f:
-                print (f"# Run system with idx {'{:04d}'.format(idx)}", file = f)
-                print (f"pushd {cwd}", file = f)
-                print (command, file = f)
-                print ("popd", file = f)
-                print (file = f)
-        
         manage_system_params()
         for idx in range(len(self.atoms_to_run)):
             cwd = os.getcwd()
@@ -125,6 +110,7 @@ class Batch:
             link()
             _, input_file, output_file = build(self.atoms_to_run[idx])
             os.chdir('../')
-            if make_jobscript is True: write_jobscript(idx, cwd, input_file, output_file) 
+            if make_jobscript is True: 
+                write_jobscript(self, idx, os.path.join(cwd,dirname), input_file, output_file) 
 
         

--- a/statebatch/statebatch/jobutils.py
+++ b/statebatch/statebatch/jobutils.py
@@ -1,0 +1,18 @@
+def write_jobscript(batch_obj, idx, cwd, input_file, output_file):
+    n_cpus  = batch_obj.comp_spec.get('n_cpus')
+    pw_name = batch_obj.comp_spec.get('pw_name')
+    mpi_command = batch_obj.comp_spec.get('mpi_command')
+    if mpi_command is not None:
+        command = f"{mpi_command} -np {n_cpus} ./{pw_name} < {input_file} > {output_file}"
+    else:
+        command = f"./{pw_name} < {input_file} > {output_file}"
+    if (idx == 0):
+         mode = 'w'
+    else:
+         mode = 'a'
+    with open ("jobscript.txt", mode) as f:
+        print (f"# Run system with idx {'{:04d}'.format(idx)}", file = f)
+        print (f"pushd {cwd}", file = f)
+        print (command, file = f)
+        print ("popd", file = f)
+        print (file = f)


### PR DESCRIPTION
Hi, I update the code to include a function "write_jobscript". The code will make a jobscript named 'jobscript.txt' in the parent directory (**not** child directory).

To activate it, specify `make_jobscript = True` in Batch instance.
Also, please specify the 'mpi_command' in the input.yaml under the `comp_spec` section. Currently I set it to `mpirun`
```
Batch_obj = Batch('input.yaml')
Batch_obj.prerun(make_jobscript=True)
```
This is the example of `jobscript.txt`
```
# Run system with idx 0000
pushd /sqfs2/cmc/1/work/K22A12/u6b589/STATE-BATCH_2/STATE-BATCH/examples/single_atom
mpirun -np 16 ./STATE < H.in > H.out
popd

# Run system with idx 0001
pushd /sqfs2/cmc/1/work/K22A12/u6b589/STATE-BATCH_2/STATE-BATCH/examples/single_atom
mpirun -np 16 ./STATE < Li.in > Li.out
popd

# Run system with idx 0002
pushd /sqfs2/cmc/1/work/K22A12/u6b589/STATE-BATCH_2/STATE-BATCH/examples/single_atom
mpirun -np 16 ./STATE < Be.in > Be.out
popd

# Run system with idx 0003
pushd /sqfs2/cmc/1/work/K22A12/u6b589/STATE-BATCH_2/STATE-BATCH/examples/single_atom
mpirun -np 16 ./STATE < B.in > B.out
popd
```

Then user can append it to the file containing the header of qsub file. For instance in SQUID supercomputer it would be like this:
```
#! /usr/bin/bash
#PBS -q SQUID
#PBS --group=K22A12
#PBS -N FLARE
#PBS -l elapstim_req=01:00:00
#PBS -v OMP_NUM_THREADS=76
#PBS -b 1

module load BaseCPU/2022

source /sqfs/home/u6b589/miniconda3/etc/profile.d/conda.sh
conda activate myflare

cd $PBS_O_WORKDIR
```
